### PR TITLE
Don't map printable characters in the select mode

### DIFF
--- a/doc/matchit.txt
+++ b/doc/matchit.txt
@@ -389,11 +389,9 @@ try to respond to reports of bugs that cause real problems.  If it does not
 cause serious problems, or if there is a work-around, a bug may sit there for
 a while.  Moral:  if a bug (known or not) bothers you, let me know.
 
-The various |:vmap|s defined in the script (%, |g%|, |[%|, |]%|, |a%|) may
-have undesired effects in Select mode |Select-mode-mapping|.  At least, if you
-want to replace the selection with any character in "ag%[]" there will be a
-pause of |'updatetime'| first. E.g., "yV%" would normally work linewise, but
-the plugin mapping makes it characterwise.
+The various maps defined in the script may have undesired effects.  E.g.,
+"yV%" would normally work linewise, but the plugin mapping makes it
+characterwise.
 
 It would be nice if "\0" were recognized as the entire pattern.  That is, it
 would be nice if "foo:\end\0" had the same effect as "\(foo\):\end\1".  I may

--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -57,8 +57,8 @@ onoremap <silent> <Plug>(MatchitOperationBackward) v:<C-U>call <SID>Match_wrappe
 
 nmap <silent> %  <Plug>(MatchitNormalForward)
 nmap <silent> g% <Plug>(MatchitNormalBackward)
-vmap <silent> %  <Plug>(MatchitVisualForward)
-vmap <silent> g% <Plug>(MatchitVisualBackward)
+xmap <silent> %  <Plug>(MatchitVisualForward)
+xmap <silent> g% <Plug>(MatchitVisualBackward)
 omap <silent> %  <Plug>(MatchitOperationForward)
 omap <silent> g% <Plug>(MatchitOperationBackward)
 
@@ -72,14 +72,14 @@ onoremap <silent> <Plug>(MatchitOperationMultiForward)  v:<C-U>call <SID>MultiMa
 
 nmap <silent> [% <Plug>(MatchitNormalMultiBackward)
 nmap <silent> ]% <Plug>(MatchitNormalMultiForward)
-vmap <silent> [% <Plug>(MatchitVisualMultiBackward)
-vmap <silent> ]% <Plug>(MatchitVisualMultiForward)
+xmap <silent> [% <Plug>(MatchitVisualMultiBackward)
+xmap <silent> ]% <Plug>(MatchitVisualMultiForward)
 omap <silent> [% <Plug>(MatchitOperationMultiBackward)
 omap <silent> ]% <Plug>(MatchitOperationMultiForward)
 
 " text object:
 vmap <silent> <Plug>(MatchitVisualTextObject) <Plug>(MatchitVisualMultiBackward)o<Plug>(MatchitVisualMultiForward)
-vmap a% <Plug>(MatchitVisualTextObject)
+xmap a% <Plug>(MatchitVisualTextObject)
 
 " Auto-complete mappings:  (not yet "ready for prime time")
 " TODO Read :help write-plugin for the "right" way to let the user


### PR DESCRIPTION
Use `xmap` instead of `vmap` for printable characters as pointed out in #2.
Mappings in the select mode have undesired side effects.
(See also `:help Select-mode-mapping`)