### PR TITLE
fix visual percent

### DIFF
--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -46,40 +46,40 @@ let g:loaded_matchit = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-nnoremap <silent> <Plug>(MatchitNormalForward)     :<C-U>call matchit#Match_wrapper('',1,'n')<CR>
-nnoremap <silent> <Plug>(MatchitNormalBackward)    :<C-U>call matchit#Match_wrapper('',0,'n')<CR>
-xnoremap <silent> <Plug>(MatchitVisualForward)     :<C-U>call matchit#Match_wrapper('',1,'v')<CR>
+nnoremap <Plug>(MatchitNormalForward)     <Cmd>call matchit#Match_wrapper('',1,'n')<CR>
+nnoremap <Plug>(MatchitNormalBackward)    <Cmd>call matchit#Match_wrapper('',0,'n')<CR>
+xnoremap <silent> <Plug>(MatchitVisualForward) <C-\><C-N><Cmd>call matchit#Match_wrapper('',1,'v')<CR>
       \:if col("''") != col("$") \| exe ":normal! m'" \| endif<cr>gv``
-xnoremap <silent> <Plug>(MatchitVisualBackward)    :<C-U>call matchit#Match_wrapper('',0,'v')<CR>m'gv``
-onoremap <silent> <Plug>(MatchitOperationForward)  :<C-U>call matchit#Match_wrapper('',1,'o')<CR>
-onoremap <silent> <Plug>(MatchitOperationBackward) :<C-U>call matchit#Match_wrapper('',0,'o')<CR>
+xnoremap <Plug>(MatchitVisualBackward)    <Cmd>call matchit#Match_wrapper('',0,'v')<CR>m'gv``
+onoremap <Plug>(MatchitOperationForward)  <Cmd>call matchit#Match_wrapper('',1,'o')<CR>
+onoremap <Plug>(MatchitOperationBackward) <Cmd>call matchit#Match_wrapper('',0,'o')<CR>
 
 " Analogues of [{ and ]} using matching patterns:
-nnoremap <silent> <Plug>(MatchitNormalMultiBackward)    :<C-U>call matchit#MultiMatch("bW", "n")<CR>
-nnoremap <silent> <Plug>(MatchitNormalMultiForward)     :<C-U>call matchit#MultiMatch("W",  "n")<CR>
-xnoremap <silent> <Plug>(MatchitVisualMultiBackward)    :<C-U>call matchit#MultiMatch("bW", "n")<CR>m'gv``
-xnoremap <silent> <Plug>(MatchitVisualMultiForward)     :<C-U>call matchit#MultiMatch("W",  "n")<CR>m'gv``
-onoremap <silent> <Plug>(MatchitOperationMultiBackward) :<C-U>call matchit#MultiMatch("bW", "o")<CR>
-onoremap <silent> <Plug>(MatchitOperationMultiForward)  :<C-U>call matchit#MultiMatch("W",  "o")<CR>
+nnoremap <Plug>(MatchitNormalMultiBackward)    <Cmd>call matchit#MultiMatch("bW", "n")<CR>
+nnoremap <Plug>(MatchitNormalMultiForward)     <Cmd>call matchit#MultiMatch("W",  "n")<CR>
+xnoremap <Plug>(MatchitVisualMultiBackward)    <C-\><C-N><Cmd>call matchit#MultiMatch("bW", "n")<CR>m'gv``
+xnoremap <Plug>(MatchitVisualMultiForward)     <C-\><C-N><Cmd>call matchit#MultiMatch("W",  "n")<CR>m'gv``
+onoremap <Plug>(MatchitOperationMultiBackward) <Cmd>call matchit#MultiMatch("bW", "o")<CR>
+onoremap <Plug>(MatchitOperationMultiForward)  <Cmd>call matchit#MultiMatch("W",  "o")<CR>
 
 " text object:
-xmap <silent> <Plug>(MatchitVisualTextObject) <Plug>(MatchitVisualMultiBackward)o<Plug>(MatchitVisualMultiForward)
+xmap <Plug>(MatchitVisualTextObject) <Plug>(MatchitVisualMultiBackward)o<Plug>(MatchitVisualMultiForward)
 
 if !exists("g:no_plugin_maps")
-  nmap <silent> %  <Plug>(MatchitNormalForward)
-  nmap <silent> g% <Plug>(MatchitNormalBackward)
-  xmap <silent> %  <Plug>(MatchitVisualForward)
-  xmap <silent> g% <Plug>(MatchitVisualBackward)
-  omap <silent> %  <Plug>(MatchitOperationForward)
-  omap <silent> g% <Plug>(MatchitOperationBackward)
+  nmap %  <Plug>(MatchitNormalForward)
+  nmap g% <Plug>(MatchitNormalBackward)
+  xmap %  <Plug>(MatchitVisualForward)
+  xmap g% <Plug>(MatchitVisualBackward)
+  omap %  <Plug>(MatchitOperationForward)
+  omap g% <Plug>(MatchitOperationBackward)
 
   " Analogues of [{ and ]} using matching patterns:
-  nmap <silent> [% <Plug>(MatchitNormalMultiBackward)
-  nmap <silent> ]% <Plug>(MatchitNormalMultiForward)
-  xmap <silent> [% <Plug>(MatchitVisualMultiBackward)
-  xmap <silent> ]% <Plug>(MatchitVisualMultiForward)
-  omap <silent> [% <Plug>(MatchitOperationMultiBackward)
-  omap <silent> ]% <Plug>(MatchitOperationMultiForward)
+  nmap [% <Plug>(MatchitNormalMultiBackward)
+  nmap ]% <Plug>(MatchitNormalMultiForward)
+  xmap [% <Plug>(MatchitVisualMultiBackward)
+  xmap ]% <Plug>(MatchitVisualMultiForward)
+  omap [% <Plug>(MatchitOperationMultiBackward)
+  omap ]% <Plug>(MatchitOperationMultiForward)
 
   " Text object
   xmap a% <Plug>(MatchitVisualTextObject)


### PR DESCRIPTION
The `%` mapping seems broken in visual mode.

To reproduce, run this shell command:

    vim -Nu <(cat <<'EOF'
        vim9script
        set rtp^=/path/to/matchit/
        var lines =<< trim END
        aaa
        bbb
        {
        ccc
        ddd
        }
        eee
        fff
        END
        writefile(lines, '/tmp/c.c')
        sil e /tmp/c.c
        feedkeys('2GVj%')
    EOF
    )

*`/path/to/matchit/` needs to be set to the actual path of the plugin.*

Expected behavior: The block containing the lines `ccc` and `ddd` is selected.
Actual behavior: The block containing the lines `ccc` and `ddd` is not selected.

This is broken because that's not how the builtin `%` command behaves without the matchit plugin.

---

The issue disappears if we start the selection from *after* the end of the block:
```vim
vim9script
var lines =<< trim END
aaa
bbb
{
ccc
ddd
}
eee
fff
END
writefile(lines, '/tmp/c.c')
sil e /tmp/c.c
feedkeys('7GVk%')
```
---

A similar issue exists when we start the selection while the cursor is right on a brace (not on a line above):
```vim
vim9script
var lines =<< trim END
aaa
bbb
{
ccc
ddd
}
eee
fff
END
writefile(lines, '/tmp/c.c')
sil e /tmp/c.c
feedkeys('3GV%%')
```

Notice that this time, the first `%` has correctly worked: the block is selected.  But the second `%` has failed: the block should have been de-selected.

And again, the issue disappears when we start the selection from the *end* of the block rather than from its start.
```vim
vim9script
var lines =<< trim END
aaa
bbb
{
ccc
ddd
}
eee
fff
END
writefile(lines, '/tmp/c.c')
sil e /tmp/c.c
feedkeys('6GV%%')
```
---

I don't know what the right fix is yet.  But I have noticed that using the pseudo-key `<Cmd>` fixed the issue.  Using `<Cmd>` is better anyway, because it has fewer side-effects: it doesn't trigger the `Cmdline*` events.  Also, it makes the code less verbose: no need of `<silent>` nor `<C-U>`.

This bug has always annoyed me, and is one of the reasons why I've used `vim-matchup` up until now.  But I'm trying to move away from big/complex plugins as they are too time-consuming to debug.  `matchit` is much shorter/simpler (hopefully it will stay that way), so I would like this bug to be fixed to use it again.

---

Note that even though we use `<Cmd>`, we still need `<silent>` in 1 mapping.  `<Cmd>` only makes the command silent until the next `<CR>`; not beyond:

    <Cmd>call matchit#Match_wrapper('',1,'v')<CR>:if col("''") != col("$") ...
         ├──────────────────────────────────┘    ├───────────────────────────┘
         │                                       └ this is NOT silent
         └ this is silent

Also, `<C-\><C-N>` might be replaced with `<Esc>`, but in a mapping, I try to avoid the latter, because it's too ambiguous.  For example:

    vim -es -Nu NONE -S <(cat <<'EOF'
        exe "set <F31>=\ed"
        imap <c-b> <esc>ddi
        0pu=['a', 'b', 'c']
        2
        call feedkeys("i\<c-b>", 'x')
        %p
        qa!
    EOF
    )

This outputs:

    a
    <F31>dib
    c

While I would have expected:

    a
    c

The issue disappears if we replace `<Esc>` with `<C-\><C-N>`:

    vim -es -Nu NONE -S <(cat <<'EOF'
        exe "set <F31>=\ed"
        imap <c-b> <C-\><C-N>ddi
        0pu=['a', 'b', 'c']
        2
        call feedkeys("i\<c-b>", 'x')
        %p
        qa!
    EOF
    )

Bottom line: `<Esc>` is ambiguous because it can mean "start of a special keycode", or "escape to normal mode".  In contrast, `<C-\><C-N>` is not ambiguous; it can only mean "make sure I'm in normal mode" which is what we really want here.

