### PR TITLE
make sure internal state of script is preserved

### DIFF
--- a/autoload/matchit.vim
+++ b/autoload/matchit.vim
@@ -2,6 +2,9 @@
 "  autload script of matchit plugin, see ../plugin/matchit.vim
 "  Last Change: Mar 01, 2020
 
+if exists('s:loaded') | finish | endif
+let s:loaded = v:true
+
 let s:last_mps = ""
 let s:last_words = ":"
 let s:patBR = ""


### PR DESCRIPTION
The autoload script doesn't contain any anti-reinclusion guard.  It might not be necessary, but coding defensively can reduce the time spent in debugging weird issues later.

In the past, I've had several sporadic issues which were fixed by such guards.  [`vim-fugitive`](https://github.com/tpope/vim-fugitive/blob/3bf602b13d86b7aef57fec4a2df29467b61435cb/autoload/fugitive.vim#L4-L7) uses one too.

As an example – with an old Vim version – calling a public function with a typo might cause Vim to source the autoloaded script twice, which would reset some script-local variables, which in turn could lead to hard-to-debug issues.

That's no longer possible since the patch [8.2.1398](https://github.com/vim/vim/releases/tag/v8.2.1398) though.  Still, maybe the autoloaded script could be accidentally re-sourced in some other way (e.g. a `:source` or `:runtime` command with a wrong file argument).

What do you think?  Good idea, or too much?

