### PR TITLE
Fix match_skip special value parsing when 'ic' is set

### DIFF
--- a/autoload/matchit.vim
+++ b/autoload/matchit.vim
@@ -753,15 +753,15 @@ endfun
 fun! s:ParseSkip(str)
   let skip = a:str
   if skip[1] == ":"
-    if skip[0] == "s"
+    if skip[0] ==# "s"
       let skip = "synIDattr(synID(line('.'),col('.'),1),'name') =~? '" ..
         \ strpart(skip,2) .. "'"
-    elseif skip[0] == "S"
+    elseif skip[0] ==# "S"
       let skip = "synIDattr(synID(line('.'),col('.'),1),'name') !~? '" ..
         \ strpart(skip,2) .. "'"
-    elseif skip[0] == "r"
+    elseif skip[0] ==# "r"
       let skip = "strpart(getline('.'),0,col('.'))=~'" .. strpart(skip,2) .. "'"
-    elseif skip[0] == "R"
+    elseif skip[0] ==# "R"
       let skip = "strpart(getline('.'),0,col('.'))!~'" .. strpart(skip,2) .. "'"
     endif
   endif


### PR DESCRIPTION
When 'ignorecase' is set the negated special values S:Foo and R:Bar are
parsed as s:FOO and r:Bar, always matching the specified pattern.
