### PR TITLE
Unescape escaped `:` in patterns

### DIFF
--- a/autoload/matchit.vim
+++ b/autoload/matchit.vim
@@ -101,8 +101,8 @@ function matchit#Match_wrapper(word, forward, mode) range
       let s:pat = s:ParseWords(match_words)
     endif
     let s:all = substitute(s:pat, s:notslash .. '\zs[,:]\+', '\\|', 'g')
-    " un-escape \, to ,
-    let s:all = substitute(s:all, '\\,', ',', 'g')
+    " un-escape \, and \: to , and :
+    let s:all = substitute(s:all, s:notslash .. '\zs\\\(:\|,\)', '\1', 'g')
     " Just in case there are too many '\(...)' groups inside the pattern, make
     " sure to use \%(...) groups, so that error E872 can be avoided
     let s:all = substitute(s:all, '\\(', '\\%(', 'g')
@@ -538,8 +538,8 @@ fun! s:Choose(patterns, string, comma, branch, prefix, suffix, ...)
   else
     let currpat = substitute(current, s:notslash .. a:branch, '\\|', 'g')
   endif
-  " un-escape \, to ,
-  let currpat = substitute(currpat, '\\,', ',', 'g')
+  " un-escape \, and \: to , and :
+  let currpat = substitute(currpat, s:notslash .. '\zs\\\(:\|,\)', '\1', 'g')
   while a:string !~ a:prefix .. currpat .. a:suffix
     let tail = strpart(tail, i)
     let i = matchend(tail, s:notslash .. a:comma)
@@ -552,6 +552,8 @@ fun! s:Choose(patterns, string, comma, branch, prefix, suffix, ...)
     else
       let currpat = substitute(current, s:notslash .. a:branch, '\\|', 'g')
     endif
+    " un-escape \, and \: to , and :
+    let currpat = substitute(currpat, s:notslash .. '\zs\\\(:\|,\)', '\1', 'g')
     if a:0
       let alttail = strpart(alttail, j)
       let j = matchend(alttail, s:notslash .. a:comma)

--- a/doc/matchit.txt
+++ b/doc/matchit.txt
@@ -270,9 +270,9 @@ Vim's |regular-expression|s.
 
 The format for |b:match_words| is similar to that of the 'matchpairs' option:
 it is a comma (,)-separated list of groups; each group is a colon(:)-separated
-list of patterns (regular expressions).  Commas and backslashes that are part
-of a pattern should be escaped with backslashes ('\:' and '\,').  It is OK to
-have only one group; the effect is undefined if a group has only one pattern.
+list of patterns (regular expressions).  Commas and colons that are part of a
+pattern should be escaped with backslashes ('\:' and '\,').  It is OK to have
+only one group; the effect is undefined if a group has only one pattern.
 A simple example is >
 	:let b:match_words = '\<if\>:\<endif\>,'
 		\ . '\<while\>:\<continue\>:\<break\>:\<endwhile\>'


### PR DESCRIPTION
This fixes https://github.com/vim/vim/issues/14814 completely.

The issue was closed as fixed by d16766961a92ca2f4a95f59487b9448d998dacd7, but it only unescapes `,`. `\:` still has the issue. `:` should be unescaped as well.