### PR TITLE
doc: remove installation instruction from matchit.txt

### DIFF
--- a/doc/matchit.txt
+++ b/doc/matchit.txt
@@ -2,10 +2,6 @@
 
 		VIM REFERENCE MANUAL    by Benji Fisher et al
 
-For instructions on installing this file, type
-	`:help matchit-install`
-inside Vim.
-
 
 *matchit* *matchit.vim*
 


### PR DESCRIPTION
Problem:
- The note "For instruction on how to install this file" seems useless, because if users can see the file in their Vim, it means they already "install" (:packadd[!]) the matchit package.
- And if users install the plugin from upstream using other package manager (e.g vim-plug, or just clone to `pack/*/start`), this instruction would be wrong.

Solution:
- Remove that note