### PR TITLE
Minor b:match_function improvements

### DIFF
--- a/autoload/matchit.vim
+++ b/autoload/matchit.vim
@@ -1,6 +1,6 @@
 "  matchit.vim: (global plugin) Extended "%" matching
 "  autload script of matchit plugin, see ../plugin/matchit.vim
-"  Last Change: Jan 06, 2025
+"  Last Change: Jan 09, 2026
 
 " Neovim does not support scriptversion
 if has("vimscript-4")
@@ -71,9 +71,8 @@ function matchit#Match_wrapper(word, forward, mode) range
 
   " Check for custom match function hook
   if exists("b:match_function")
-    let MatchFunc = b:match_function
     try
-      let result = call(MatchFunc, [a:forward])
+      let result = call(b:match_function, [a:forward])
       if !empty(result)
         call cursor(result)
         return s:CleanUp(restore_options, a:mode, startpos)

--- a/doc/matchit.txt
+++ b/doc/matchit.txt
@@ -282,8 +282,8 @@ Python example (simplified): >
 	  let pattern = get(s:keywords, keyword, '')
 	  if empty(pattern) | return [] | endif
 
-	  let flags = a:forward ? 'nW' : 'nbW'
-	  let [lnum, col] = searchpos('^\s*\%(' . pattern . '\)\>', flags, 0, 0,
+	  " Forward-only. Backwards left as an exercise for the reader.
+	  let [lnum, col] = searchpos('^\s*\%(' . pattern . '\)\>', 'nW' 0, 0,
 	  \                            'indent(".") != ' . indent('.'))
 	  return lnum > 0 ? [lnum, col] : []
 	endfunction


### PR DESCRIPTION
First, update the simplified Python example to only demonstrate forward matching. Backwards matching requires needs to evaluate a different set of patterns. We'll leave that implementation as an exercise to the reader.

Second, the MatchFunc variable was only used once, so remove it. (I used it multiple times in an earlier local revision and forgot to simplify.)