### PR TITLE
fix: Jump using % do not work in some situations

### DIFF
--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -50,7 +50,7 @@ fun MatchEnable()
   nnoremap <silent> <Plug>(MatchitNormalForward)     :<C-U>call matchit#Match_wrapper('',1,'n')<CR>
   nnoremap <silent> <Plug>(MatchitNormalBackward)    :<C-U>call matchit#Match_wrapper('',0,'n')<CR>
   xnoremap <silent> <Plug>(MatchitVisualForward)     :<C-U>call matchit#Match_wrapper('',1,'v')<CR>
-        \:if col("''") != col("$") \| exe ":normal! m'" \| endif<cr>gv``
+        \:if line("''") != line(".") \|\| col("''") != col("$") \| exe ":normal! m'" \| endif<cr>gv``
   xnoremap <silent> <Plug>(MatchitVisualBackward)    :<C-U>call matchit#Match_wrapper('',0,'v')<CR>m'gv``
   onoremap <silent> <Plug>(MatchitOperationForward)  :<C-U>call matchit#Match_wrapper('',1,'o')<CR>
   onoremap <silent> <Plug>(MatchitOperationBackward) :<C-U>call matchit#Match_wrapper('',0,'o')<CR>


### PR DESCRIPTION
This MR is the follow-up for closed https://github.com/neovim/neovim/pull/39966

For the following snippet:

```
object(
) {
},
```

do the following: `gg0V$%$%`

expected result: all snippet is selected
actual result: last line is not selected

Also fixes #40
Also fixes #29 without reintroducton of #24
Also fixes #47 