### PR TITLE
Escape all pattern metacharacters in backref replacements

### DIFF
--- a/autoload/matchit.vim
+++ b/autoload/matchit.vim
@@ -339,8 +339,8 @@ fun! s:InsertRefs(groupBR, prefix, group, suffix, matchline)
     if table[d] != "-"
       let backref = substitute(a:matchline, a:prefix .. word .. a:suffix,
         \ '\' .. table[d], "")
-        " Are there any other characters that should be escaped?
-      let backref = escape(backref, '*,:')
+      " escape magic pattern metacharacters and matchit special characters [,:]
+      let backref = escape(backref, '\.*[^$~,:')
       execute s:Ref(ini, d, "start", "len")
       let ini = strpart(ini, 0, start) .. backref .. strpart(ini, start+len)
       let tailBR = substitute(tailBR, s:notslash .. '\zs\\' .. d,


### PR DESCRIPTION
This allows capture groups to include pattern metacharacters as literal
text.  E.g., let b:match_words = 'start-\(foo\\bar\):end-\1' match

start-foo\bar
end-foo\bar
